### PR TITLE
Start a template to set up a datalad bids root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # template_datalad_bids-raw
+
+## TO DO
+
+- [ ] add how to generate this template (fork with all branches to also get git-annex)
+- [ ] add that on gin, you need to change which branch to visualize
+- [ ] bids example as folder tree

--- a/dataladSetUp.sh
+++ b/dataladSetUp.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# for instructions on how to name it according to the lab guide
+# see https://github.com/cpp-lln-lab/dataset_maintenance 
+# example: 3018_Shire_LOTR_FB_raw
+GIN_BASENAME=''
+
+root_dir=${PWD}
+source_dir=${root_dir}/sourcedata
+# optional
+# derivatives_dir=${root_dir}/derivatives
+
+# create the repo on gin for the root directory
+
+datalad create-sibling-gin -d . -s origin --access-protocol ssh --private   cpp-lln-lab/"${GIN_BASENAME}"
+
+# create the sourcedata for DICOMS as a separate subdataset 
+datalad create -d . -c text2git "${source_dir}" 
+
+# enter the sourcedata and from there create the repo (sourcedata's sibling) on gin server
+cd "${source_dir}"
+
+datalad create-sibling-gin -d . -s origin --access-protocol ssh --private   cpp-lln-lab/"${GIN_BASENAME}"-source
+    
+#re set the gin url on the root
+cd "${root_dir}"
+
+datalad subdatasets --set-property url https://gin.g-node.org/cpp-lln-lab/"${GIN_BASENAME}"-source "${sourcedata}"
+
+# repeat the process for derivatives if necessary
+if [ ! -z "${derivatives_dir}" ]; then
+
+    datalad create -d . "${derivatives_dir}"
+
+    cd "${derivatives_dir}"
+    datalad create-sibling-gin -d . -s origin --access-protocol ssh --private  cpp-lln-lab/"${GIN_BASENAME}"-derivatives
+
+    cd "${root_dir}"
+    datalad subdatasets --set-property url https://gin.g-node.org/cpp-lln-lab/"${GIN_BASENAME}"-derivatives derivatives
+
+fi
+
+cd "${root_dir}"
+
+datalad push --to origin -r
+
+echo "############################"
+echo "# DATALAD IS READY TO WORK #"
+echo "############################"


### PR DESCRIPTION
Just sick to repeat the same process any time I create a new raw dataset :)

@Jaceck I put in `dataladSetUp.sh` my workflow to create local and gin repos for a raw dataset. We can through it together. If you want to start yourself setting up a raw dataset from this template (after pr merge) just remember to grab all the branches (click on "use this tempalte", on the page where you set the name of your repo tick "include all branches" otherwise datalad is fucked up)

@Remi do you you think it could be useful? We could think to add also the rest as a template (dataset json and participant tsv)

cheers